### PR TITLE
fix(ui/mobile): Stabilize header and update branding gradient

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -225,11 +225,17 @@ export default function App() {
       
       <div className="flex-1 flex flex-col min-w-0">
         {/* Mobile Header */}
-        <div className="md:hidden flex items-center p-4 border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+        {/* FIX: Add sticky/z-index to lock the header to the top of the viewport/container. 
+           We also ensure the background is opaque to cover scrolling content. */}
+        <div className="md:hidden sticky top-0 z-40 flex items-center p-4 border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
           <button onClick={() => setIsSidebarOpen(true)} className="p-2 -ml-2 mr-2 text-gray-600 dark:text-gray-400">
             <Menu size={24} />
           </button>
-          <span className="font-bold text-lg text-transparent bg-clip-text bg-gradient-to-r from-blue-700 to-indigo-600 dark:from-blue-400 dark:to-indigo-400">VolumeVault21</span>
+          {/* FIX: Updated gradient colors to #DD3D2D and #F67E4B */}
+          <span className="font-bold text-lg text-transparent bg-clip-text bg-gradient-to-r"
+                style={{backgroundImage: 'linear-gradient(to right, #DD3D2D, #F67E4B)'}}>
+            VolumeVault21
+          </span>
         </div>
         
         {loading ? (

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -80,7 +80,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
     `}>
       {/* Header */}
       <div className="p-4 border-b border-gray-200 dark:border-gray-800 flex justify-between items-center">
-        <h1 className="text-xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-blue-700 to-indigo-500 dark:from-blue-400 dark:to-indigo-300 tracking-tight">
+        <h1 className="text-xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-blue-700 to-indigo-500 dark:from-blue-400 dark:to-indigo-300 tracking-tight"
+            style={{backgroundImage: 'linear-gradient(to right, #DD3D2D, #F67E4B)'}}>
           {isTrash ? 'Trash Bin' : 'VolumeVault21'}
         </h1>
         <button onClick={onCloseMobile} className="md:hidden p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400">


### PR DESCRIPTION
Locks the mobile header (md:hidden) to the top of the viewport using sticky positioning to prevent it from disappearing during scrolling. Updates the branding gradient color for 'VolumeVault21' across App.tsx and Sidebar.tsx.