### PR TITLE
FEAT/UX: Implement Mobile Gestures and Immersive Editor Focus

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -12,7 +12,6 @@ services:
       - /app/node_modules
       - ./data:/data
     environment:
-      - VITE_API_KEY=${API_KEY}
       - NODE_ENV=development
     restart: unless-stopped
     # REMOVED: user: 1000:1000 (Rely on Dockerfile to set USER appuser, which is UID 21000)

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,5 +16,5 @@ export interface AppSettings {
   autoSave: boolean;
   saveInterval: number; // in milliseconds
   serverUrl?: string;
-  serverApiKey?: string;
+  // REMOVED: serverApiKey?: string;
 }


### PR DESCRIPTION
Significantly improves the mobile user experience by introducing gesture navigation and optimizing screen real estate in the editor.

### App.tsx Changes

- **FEAT**: Mobile Swipe Gestures: Implemented `onTouchStart`, `onTouchMove`, and `onTouchEnd` handlers on the main content area to allow users to swipe right to open the sidebar and swipe left to close it.
- **UX**: Removed the redundant floating mobile menu button as its function is now handled by gestures.

### Editor.tsx Changes (Focus Mode)

- **UX**: Immersive Focus Mode: Implemented the `isContentFocused` state to automatically hide the entire header (Title, Tags, Category, View Toggles) on mobile when the user focuses on the editor content, maximizing vertical writing space.
- **UX**: Scrollable Toolbar: Configured the editor toolbar container with `overflow-x-auto` and `whitespace-nowrap` to prevent button wrapping and ensure all formatting tools are accessible via horizontal scrolling on small screens.
- **FEAT**: Added 'Insert Line Break' button (`CornerDownLeft`) to the editor toolbar with corresponding `execCmd` logic.