### PR TITLE
CONFIG/UX: Finalize Remote Sync Configuration and Docker Cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# Dockerfile
-
 FROM node:20-alpine
 
 WORKDIR /app
@@ -20,7 +18,7 @@ COPY . .
 ENV CI=false
 
 # --- PRODUCTION BUILD STEP ---
-# CRITICAL FIX: Set NODE_PATH to explicitly point to node_modules ONLY for the build command.
+# Set NODE_PATH to explicitly point to node_modules ONLY for the build command.
 # This ensures PostCSS and Vite can find 'tailwindcss' within the container's environment.
 RUN NODE_PATH=/app/node_modules npm run build
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,4 @@
 name: volumevault21
-
 services:
   app:
     image: volumedata21/volumevault21:latest

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,5 +16,4 @@ export interface AppSettings {
   autoSave: boolean;
   saveInterval: number; // in milliseconds
   serverUrl?: string;
-  // REMOVED: serverApiKey?: string;
 }


### PR DESCRIPTION
Completes the setup for self-hosting reliability by integrating the Server URL into settings and cleaning up deployment configuration files.

### SettingsModal.tsx

- **FEAT**: Added "Backend URL" input field to the Server Sync section, allowing users to explicitly configure the API endpoint for direct IP access or complex deployments.
- **CHORE**: Implemented local state (`localServerUrl`) and saved it upon modal closure or manual sync, ensuring the correct URL is passed to the note service.

### noteService.ts

- **FIX**: Integrated `serverUrl` parameter into `getAllNotes` and `syncNotes` network operations, enabling the application to correctly target a remote API server defined by the user settings.

### compose.yaml / Dockerfile Cleanup

- **CONFIG**: Finalized production `compose.yaml` to run a single service on port 2100 with correct user permissions (`user: 21000:21000`) for data persistence (`./data`).
- **CHORE**: Cleaned up the Dockerfile by removing unnecessary "CRITICAL FIX" comments related to `NODE_PATH`, as the configuration is now stable.
- **DOCS**: Confirmed that the client intelligently uses relative paths when the URL setting is empty, ensuring seamless operation behind a reverse proxy (e.g., notes.mysite.com).